### PR TITLE
Update package.json to add `node-gyp` dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "inquirer": "^0.9.0",
     "keypress": "^0.2.1",
     "mplayer": "^2.0.1",
+    "node-gyp": "^3.5.0",
     "npmlog": "^2.0.3",
     "npr-api": "^2.0.0",
     "rimraf": "^2.5.2",


### PR DESCRIPTION
If this builds on the Raspberry Pi (I don't currently have one), and I know you have limited space, but it doesn't look to be a large space addition when built; then it would build cleanly cross-platform. This works on linux and OSX.

`node-gyp 3.5.0` is -current, and is what I pulled on install, I have not tested earlier version.